### PR TITLE
Put back algorithm names and custom zone option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,58 +4,55 @@ Updated 2015/02/17 with better timeout and retry selector. (Warren Kumari warren
 Updated 2015/04/01 with better instructions. 
 
 A simple program to check which DNSSEC algorithms a particular resolver
-validates. 
-This program is written in Go and it is the first real program I wrote using go routines. 
-It uses the go routines to perform the checks in parallel. 
-Some resolvers return lots of timeouts when this program runs against
-them, just wait few seconds and then rerun the program for better results. 
+validates.  This program is written in Go and it is the first real program I
+wrote using go routines.  It uses the go routines to perform the checks in
+parallel.  Some resolvers return lots of timeouts when this program runs against
+them, just wait few seconds and then rerun the program for better results.
 
-Note: IF this is the FIRST time you use the go language you need to 
-  a) download and install go first here for instructions https://golang.org/doc/install
-  b) need to set a GOPATH variable in your environment, see https://golang.org/doc/code.html#GOPATH
+**Note:** IF this is the FIRST time you use the go language you need to
 
-This program requires the package miekg/dns which can be added by issuing 
+  1. download and install go first here for instructions https://golang.org/doc/install
+  2. need to set a GOPATH variable in your environment, see https://golang.org/doc/code.html#GOPATH
 
-     "go get github.com/miekg/dns"
+This program requires the package `miekg/dns` which can be added by issuing 
+
+    go get github.com/miekg/dns
 
 and build the program by issuing
-     "go build alg_rep.go" 
 
-By this program has an aggressive timeout (.5s) to ensure it runs quickly. 
+    go build alg_rep.go
 
-Command line arguments: ./alg_rep: [-r resolver] [-d] [-v] 
-```
-  -d=false: All debug on
 
-  -r="8.8.8.8": address host or host:port of the DNS resolver to use 
+Command line arguments: `./alg_rep: [-r resolver] [-z zone] [-d] [-v]`
 
-  -v=false: Short output
+    -d=false: All debug on
+    -r="8.8.8.8": Address host or host:port of DNS resolver
+    -v=false: Short output
+    -z="dnssec-test.org.": Domain to use for checking
 
-  Setting the -d option will give lots more output 
 
-  `-d` should only be used when checking strange results as the output is excessive and 
+`-d` should only be used when checking strange results as the output is excessive and 
      only for experts to interpret. 
-```
 
-Note: the program has short timeouts due to the large number of queries asked
-If there are many timeout's re-running the program will most of the time get answers without timeouts. 
+**Note:** the program has short timeouts due to the large number of queries asked
+If there are many timeout's re-running the program will most of the time get answers without timeouts.
 
-Sample output: ./alg_rep -r 8.8.4.4  
-```
-Zone dnssec-test.org.  Qtype DNSKEY Resolver 8.8.8.8 debug=false verbose=false Prime= V
-DS     :  1  2  3  4  |  1  2  3  4
-ALGS   :    NSEC      |     NSEC3
-alg-1  :  S  S  S  S  |  x  x  x  x  => RSAMD5
-alg-3  :  -  -  -  -  |  x  x  x  x  => DSA
-alg-5  :  V  V  -  V  |  x  x  x  x  => RSASHA1
-alg-6  :  x  x  x  x  |  -  -  -  -  => DSA-NSEC3-SHA1
-alg-7  :  x  x  x  x  |  V  V  -  V  => RSASHA1-NSEC3
-alg-8  :  V  V  -  V  |  V  V  -  V  => RSASHA-256
-alg-10 :  V  V  -  V  |  V  V  -  V  => RSASHA-512
-alg-12 :  -  -  -  -  |  -  -  -  -  => ECC-GOST
-alg-13 :  V  V  -  V  |  V  V  -  V  => ECSDAP256-SHA256
-alg-14 :  V  V  -  V  |  V  V  -  V  => ECSDAP384-SHA384
-V == Validates  - == Answer  x == Alg Not specified
-T == Timeout S == ServFail O == Other Error
-DS algs 1=SHA1 2=SHA2-256 3=GOST 4=SHA2-384
-```
+Sample output: `./alg_rep -r 8.8.4.4`
+
+    Zone dnssec-test.org.  Qtype DNSKEY Resolver [8.8.4.4] debug=false verbose=false
+    Prime= V 
+    DS     :  1  2  3  4  |  1  2  3  4
+    ALGS   :    NSEC      |     NSEC3
+    alg-1  :  S  S  S  S  |  x  x  x  x  => RSA-MD5 OBSOLETE
+    alg-3  :  -  -  -  -  |  x  x  x  x  => DSA/SHA1
+    alg-5  :  V  V  -  V  |  x  x  x  x  => RSA/SHA1
+    alg-6  :  x  x  x  x  |  -  -  -  -  => DSA-NSEC3-SHA1
+    alg-7  :  x  x  x  x  |  V  V  -  V  => RSA-NSEC3-SHA1
+    alg-8  :  V  V  -  V  |  V  V  -  V  => RSA-SHA256
+    alg-10 :  V  V  -  V  |  V  V  -  V  => RSA-SHA512
+    alg-12 :  -  -  -  -  |  -  -  -  -  => GOST-ECC
+    alg-13 :  V  V  -  V  |  V  V  -  V  => ECDSAP256SHA256
+    alg-14 :  V  V  -  V  |  V  V  -  V  => ECDSAP384SHA384
+    V == Validates  - == Answer  x == Alg Not specified
+    T == Timeout S == ServFail O == Other Error
+    DS algs 1=SHA1 2=SHA2-256 3=GOST 4=SHA2-384

--- a/alg_rep.go
+++ b/alg_rep.go
@@ -32,6 +32,10 @@ const maxDs = 4
 
 var algs = [maxAlg]string{"alg-1", "alg-3", "alg-5", "alg-6", "alg-7", "alg-8",
 	"alg-10", "alg-12", "alg-13", "alg-14"}
+var names = [maxAlg] string {"RSA-MD5 OBSOLETE", "DSA/SHA1", "RSA/SHA1",
+	"DSA-NSEC3-SHA1", "RSA-NSEC3-SHA1", "RSA-SHA256", "RSA-SHA512",
+	"GOST-ECC", "ECDSAP256SHA256", "ECDSAP384SHA384"}
+
 
 // List the define DS digiest alogrithms As of 2014/11
 var ds = [maxDs]string{"ds-1", "ds-2", "ds-3", "ds-4"}
@@ -125,7 +129,8 @@ func print_table() {
 		if len(msg) < 6 {
 			msg += " "
 		}
-		fmt.Printf("%s\n", msg+" : "+list_supp(result[a]))
+		fmt.Printf("%s\n", msg+" : "+list_supp(result[a])+" => "+
+			names[a])
 	}
 	fmt.Printf("V == Validates  - == Answer  x == Alg Not specified\n" +
 		"T == Timeout S == ServFail O == Other Error\n" +

--- a/alg_rep.go
+++ b/alg_rep.go
@@ -64,14 +64,16 @@ func work(d int, myType uint16, resolver string, verb bool, done chan bool) {
  */
 func main() {
 	// Get commandline arguments
-	resolver := flag.String("r", "8.8.8.8", "address host or host:port of DNS resolver")
+	resolver := flag.String("r", "8.8.8.8", "Address host or host:port of DNS resolver")
 	deb := flag.Bool("d", false, "All debug on")
 	verbose := flag.Bool("v", false, "Short output")
+	myZone := flag.String("z", "dnssec-test.org.", "Domain to use for checking")
 	flag.Parse()
 	// Extract supplied parameters
 	myType := uint16(48) // DNSKEY GetType(qtype)
 	debug = *deb
 	myRes := *resolver
+	zone := *myZone
 	if myRes[0:1] != "[" {
 		myRes = "[" + myRes + "]"
 	}
@@ -174,7 +176,7 @@ func doLookup(qn string, qt uint16, resolver string) (*dns.Msg, bool) {
 func validate_name(qn string, qt uint16, resolver string, debug bool) (supp string, msg string) {
 	name, timeout := doLookup(qn, qt, resolver)
 	if timeout {
-		return " T ", "Lookup Errorr"
+		return " T ", "Lookup Error"
 	}
 	supp = " - "
 	counts := number[len(name.Answer)] + " " + number[len(name.Ns)] + " " + number[len(name.Extra)]


### PR DESCRIPTION
Hi,
I've just found out the last commit reverts previous commits showing algorithm names and enabling using a custom zone. This PR puts them back, together with a little cleanup of the README.
